### PR TITLE
Update rosinstall to pull in sawyer_moveit

### DIFF
--- a/sawyer_robot.rosinstall
+++ b/sawyer_robot.rosinstall
@@ -13,3 +13,8 @@
     #uri: https://github.com/RethinkRobotics/sawyer_robot.git
     uri: git@github.com:RethinkRobotics/sawyer_robot.git
     version: release-5.0.4
+- git:
+    local-name: sawyer_moveit
+    #uri: https://github.com/RethinkRobotics/sawyer_moveit.git
+    uri: git@github.com:RethinkRobotics/sawyer_moveit.git
+    version: release-5.0.4


### PR DESCRIPTION
Moving towards tighter integration with MoveIt for Sawyer, we are adding this repo to the `rosinstall` file.