### PR TITLE
Add robot sim hardware as SawyerRobotHWSim

### DIFF
--- a/sawyer_description/urdf/sawyer_base.gazebo.xacro
+++ b/sawyer_description/urdf/sawyer_base.gazebo.xacro
@@ -4,7 +4,7 @@
   <gazebo>
     <plugin name="sawyer_ros_control" filename="libsawyer_gazebo_ros_control.so">
       <robotNamespace>/robot</robotNamespace>
-      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+      <robotSimType>sawyer_gazebo/SawyerRobotHWSim</robotSimType>
       <controlPeriod>0.001</controlPeriod>
     </plugin>
   </gazebo>


### PR DESCRIPTION
SawyerRobotHWSim is now part of the sawyer_gazebo
package. See sawyer_gazebo/robot_hw_sim_plugins.xml
for plugin details.