### PR TITLE
Added feedback tag to allow joint torque readings

### DIFF
--- a/sawyer_description/urdf/sawyer_base.gazebo.xacro
+++ b/sawyer_description/urdf/sawyer_base.gazebo.xacro
@@ -23,27 +23,35 @@
   </gazebo>
   <gazebo reference="head_pan">
     <implicitSpringDamper>1</implicitSpringDamper>
+    <provideFeedback>true</provideFeedback>
   </gazebo>
   <gazebo reference="right_j0">
     <implicitSpringDamper>1</implicitSpringDamper>
+    <provideFeedback>true</provideFeedback>
   </gazebo>
   <gazebo reference="right_j1">
     <implicitSpringDamper>1</implicitSpringDamper>
+    <provideFeedback>true</provideFeedback>
   </gazebo>
   <gazebo reference="right_j2">
     <implicitSpringDamper>1</implicitSpringDamper>
+    <provideFeedback>true</provideFeedback>
   </gazebo>
   <gazebo reference="right_j3">
     <implicitSpringDamper>1</implicitSpringDamper>
+    <provideFeedback>true</provideFeedback>
   </gazebo>
   <gazebo reference="right_j4">
     <implicitSpringDamper>1</implicitSpringDamper>
+    <provideFeedback>true</provideFeedback>
   </gazebo>
   <gazebo reference="right_j5">
     <implicitSpringDamper>1</implicitSpringDamper>
+    <provideFeedback>true</provideFeedback>
   </gazebo>
   <gazebo reference="right_j6">
     <implicitSpringDamper>1</implicitSpringDamper>
+    <provideFeedback>true</provideFeedback>
   </gazebo>
   <!-- Gazebo-Specific Sensor Properties -->
   <gazebo reference="head_camera">


### PR DESCRIPTION
This is not currently required, but will be needed to use Gazebo's [`GetForceTorque`](http://osrf-distributions.s3.amazonaws.com/gazebo/api/7.0.0/classgazebo_1_1physics_1_1Joint.html#a924807d32ef42bd741911ff33e7f3d53) and simulate Series Elastic Actuator Torque in the future:

```
virtual JointWrench gazebo::physics::Joint::GetForceTorque ( unsigned int _index )
  get internal force and torque values at a joint.
  Note that for ODE you must set <provide_feedback>true<provide_feedback> in the joint sdf to use this.
```