### PR TITLE
Fixed head_display image VideoVisual Gazebo Plugin

### DIFF
--- a/sawyer_description/urdf/sawyer_base.gazebo.xacro
+++ b/sawyer_description/urdf/sawyer_base.gazebo.xacro
@@ -138,12 +138,12 @@
       </plugin>
     </sensor>
   </gazebo>
-  <gazebo reference="display">
+  <gazebo reference="screen">
     <visual>
       <plugin name="screen_video_controller" filename="libgazebo_ros_video.so">
         <height>600</height>
         <width>1024</width>
-        <topicName>/robot/display</topicName>
+        <topicName>/robot/head_display</topicName>
         <robotNamespace>/robot</robotNamespace>
       </plugin>
     </visual>


### PR DESCRIPTION
- Fixes the reference to "Screen" link
- Fixes `topicName` to correctly correspond to `/robot/head_display`