### PR TITLE
Added flat electric gripper finger tips

### DIFF
--- a/sawyer_description/urdf/sawyer_electric_gripper.urdf.xacro
+++ b/sawyer_description/urdf/sawyer_electric_gripper.urdf.xacro
@@ -14,10 +14,10 @@
                                   use_connector_plate="true"
                                   l_finger="standard_narrow"
                                   l_finger_slot="2"
-                                  l_finger_tip="half_round_tip"
+                                  l_finger_tip="basic_soft_tip"
                                   l_finger_grasp="inner"
                                   r_finger="standard_narrow"
                                   r_finger_slot="2"
-                                  r_finger_tip="half_round_tip"
+                                  r_finger_tip="basic_soft_tip"
                                   r_finger_grasp="inner"/>
 </robot>


### PR DESCRIPTION
The `half_round` fingertips are problematic in Gazebo, as they reduce the contact area between the fingers and the object being grasped. In the real world, the finger tips deform to the object slightly. There is currently no way to model that interaction well in Gazebo. This causes a very small contact area, so currently the best bet is to change the default gripper tip.