### PR TITLE
 URDF & Xacro Arg Updates

### DIFF
--- a/sawyer_description/urdf/sawyer.urdf.xacro
+++ b/sawyer_description/urdf/sawyer.urdf.xacro
@@ -2,16 +2,25 @@
 <robot name="sawyer" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:arg name="gazebo" default="false"/>
+  <xacro:arg name="pedestal" default="true"/>
+  <xacro:arg name="static" default="true"/>
   <xacro:arg name="electric_gripper" default="false"/>
   <!-- Sawyer Base URDF -->
   <xacro:include filename="$(find sawyer_description)/urdf/sawyer_base.urdf.xacro">
     <xacro:arg name="gazebo" value="${gazebo}"/>
+    <xacro:arg name="pedestal" value="${pedestal}"/>
   </xacro:include>
+  <xacro:if value="$(arg gazebo)">
+  <xacro:include filename="$(find sawyer_description)/urdf/sawyer_base.gazebo.xacro">
+    <xacro:arg name="static" value="${static}"/>
+    <xacro:arg name="pedestal" value="${pedestal}"/>
+  </xacro:include>
+  </xacro:if>
   <!-- Electric Gripper End Effector -->
   <xacro:if value="$(arg electric_gripper)">
-    <xacro:include filename="$(find sawyer_description)/urdf/sawyer_electric_gripper.urdf.xacro">
-      <xacro:arg name="gazebo" value="${gazebo}"/>
-    </xacro:include>
+  <xacro:include filename="$(find sawyer_description)/urdf/sawyer_electric_gripper.urdf.xacro">
+    <xacro:arg name="gazebo" value="${gazebo}"/>
+  </xacro:include>
   </xacro:if>
 
 </robot>

--- a/sawyer_description/urdf/sawyer_base.gazebo.xacro
+++ b/sawyer_description/urdf/sawyer_base.gazebo.xacro
@@ -1,5 +1,7 @@
 <?xml version="1.0" ?>
 <robot name="baxter" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="pedestal" default="true"/>
+  <xacro:arg name="static" default="true"/>
   <!-- ros_control plugin -->
   <gazebo>
     <plugin name="sawyer_ros_control" filename="libsawyer_gazebo_ros_control.so">
@@ -10,14 +12,19 @@
     </plugin>
   </gazebo>
   <!-- Gazebo-Specific Link Properties -->
+<xacro:if value="$(arg static)">
   <link name="world"/>
-    <joint name="fixed" type="fixed">
+  <joint name="fixed" type="fixed">
       <parent link="world"/>
       <child link="base"/>
   </joint>
+</xacro:if>
+<xacro:if value="$(arg pedestal)">
   <gazebo reference="pedestal">
     <material>Gazebo/FlatBlack</material>
   </gazebo>
+</xacro:if>
+
   <gazebo reference="torso">
     <self_collide>true</self_collide>
   </gazebo>

--- a/sawyer_description/urdf/sawyer_base.urdf.xacro
+++ b/sawyer_description/urdf/sawyer_base.urdf.xacro
@@ -1,21 +1,7 @@
 <?xml version="1.0" ?>
 <robot name="sawyer" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:arg name="gazebo" default="false"/>
-  <xacro:if value="$(arg gazebo)">
-    <!-- Gazebo Tags -->
-    <xacro:include filename="$(find sawyer_description)/urdf/sawyer_base.gazebo.xacro" />
-  </xacro:if>
-
-  <xacro:macro name="gazebo_minimum_inertia">
-  <!--  In Gazebo, links with zero principal moment of inertia (ixx, iyy, izz) could lead to infinite acceleration under any finite torque application.
-      http://gazebosim.org/tutorials/?tut=ros_urdf -->
-    <inertial>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <mass value="0.01"/>
-      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
-    </inertial>
-  </xacro:macro>
-
+  <xacro:arg name="pedestal" default="true"/>
   <material name="black">
     <color rgba="0 0 0 1"/>
   </material>
@@ -31,11 +17,7 @@
   <material name="sawyer_gray">
     <color rgba="0.75294 0.75294 0.75294 1"/>
   </material>
-  <link name="base">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
-  </link>
+  <link name="base"/>
   <link name="torso">
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -46,9 +28,6 @@
         <color rgba=".2 .2 .2 1"/>
       </material>
     </visual>
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
 <xacro:unless value="$(arg gazebo)">
     <inertial>
       <origin rpy="0 0 0" xyz="0.000000 0.000000 0.000000"/>
@@ -57,6 +36,7 @@
     </inertial>
 </xacro:unless>
   </link>
+<xacro:if value="$(arg pedestal)">
   <link name="pedestal">
     <visual>
       <origin rpy="1.57079632679 0 -1.57079632679" xyz="0.26 0.345 -0.91488"/>
@@ -84,9 +64,6 @@
         <box size="0.22 0.4 0.53"/>
       </geometry>
     </collision>
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
   </link>
   <joint name="controller_box_fixed" type="fixed">
     <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
@@ -100,29 +77,27 @@
         <box size="0.77 0.7 0.31"/>
       </geometry>
     </collision>
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
   </link>
   <joint name="pedestal_feet_fixed" type="fixed">
     <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
     <parent link="base"/>
     <child link="pedestal_feet"/>
   </joint>
-  <joint name="torso_t0" type="fixed">
-    <origin rpy="0 0 0" xyz="0 0 0"/>
-    <parent link="base"/>
-    <child link="torso"/>
-  </joint>
   <joint name="pedestal_fixed" type="fixed">
     <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
     <parent link="base"/>
     <child link="pedestal"/>
   </joint>
+</xacro:if>
   <joint name="right_arm_mount" type="fixed">
     <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
     <parent link="base"/>
     <child link="right_arm_base_link"/>
+  </joint>
+  <joint name="torso_t0" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base"/>
+    <child link="torso"/>
   </joint>
   <link name="right_arm_base_link">
     <inertial>
@@ -171,7 +146,7 @@
     <axis xyz="0 0 1"/>
     <limit effort="80.0" lower="-3.0503" upper="3.0503" velocity="1.74"/>
 <xacro:if value="$(arg gazebo)">
-    <dynamics damping="15.0" friction="5.0"/>
+    <dynamics damping="5.0" friction="2.0"/>
 </xacro:if>
   </joint>
   <link name="head">
@@ -205,9 +180,6 @@
 </xacro:if>
   </joint>
   <link name="right_torso_itb">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
 <xacro:unless value="$(arg gazebo)">
     <inertial>
       <origin rpy="0 0 0" xyz="0.000000 0.000000 0.000000"/>
@@ -309,7 +281,7 @@
     <axis xyz="0 0 1"/>
     <limit effort="40.0" lower="-3.0439" upper="3.0439" velocity="1.957"/>
  <xacro:if value="$(arg gazebo)">
-    <dynamics damping="15.0" friction="5.0"/>
+    <dynamics damping="1.0" friction="0.5"/>
 </xacro:if>
   </joint>
   <link name="right_l4">
@@ -339,13 +311,10 @@
     <axis xyz="0 0 1"/>
     <limit effort="9.0" lower="-2.9761" upper="2.9761" velocity="3.485"/>
 <xacro:if value="$(arg gazebo)">
-    <dynamics damping="6.0" friction="1.0"/>
+    <dynamics damping="2.0" friction="1.0"/>
 </xacro:if>
   </joint>
   <link name="right_arm_itb">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
 <xacro:unless value="$(arg gazebo)">
     <inertial>
       <origin rpy="0 0 0" xyz="0.000000 0.000000 0.000000"/>
@@ -387,25 +356,17 @@
     <axis xyz="0 0 1"/>
     <limit effort="9.0" lower="-2.9761" upper="2.9761" velocity="3.485"/>
 <xacro:if value="$(arg gazebo)">
-    <dynamics damping="5.5" friction="1.2"/>
+    <dynamics damping="1.0" friction="0.5"/>
 </xacro:if>
   </joint>
-  <link name="right_hand_camera">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
-  </link>
+  <link name="right_hand_camera"/>
   <joint name="right_hand_camera" type="fixed">
     <origin rpy="0 1.57079632679 0" xyz="0.039552 -0.033 0.0695"/>
     <parent link="right_l5"/>
     <child link="right_hand_camera"/>
     <axis xyz="0 0 0"/>
   </joint>
-  <link name="right_wrist">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
-  </link>
+  <link name="right_wrist"/>
   <joint name="right_wrist" type="fixed">
     <origin rpy="1.57079632679 0 0" xyz="0 0 0.10541"/>
     <parent link="right_l5"/>
@@ -453,7 +414,11 @@
       </geometry>
     </collision>
 <xacro:if value="$(arg gazebo)">
-      <xacro:gazebo_minimum_inertia />
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0.1 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.01" ixy="0.01" ixz="0.01" iyy="0.01" iyz="0.01" izz="0.01"/>
+  </inertial>
 </xacro:if>
 <xacro:unless value="$(arg gazebo)">
     <inertial>
@@ -470,9 +435,6 @@
     <child link="right_hand"/>
   </joint>
   <link name="right_l1_2">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
 <xacro:unless value="$(arg gazebo)">
     <inertial>
       <origin rpy="0 0 0" xyz="1.0E-08 1.0E-08 1.0E-08"/>
@@ -494,9 +456,6 @@
     <axis xyz="0 0 1"/>
   </joint>
   <link name="right_l2_2">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
 <xacro:unless value="$(arg gazebo)">
     <inertial>
       <origin rpy="0 0 0" xyz="1.0E-08 1.0E-08 1.0E-08"/>
@@ -518,9 +477,6 @@
     <axis xyz="0 0 1"/>
   </joint>
   <link name="right_l4_2">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
 <xacro:unless value="$(arg gazebo)">
     <inertial>
       <origin rpy="0 0 0" xyz="1.0E-08 1.0E-08 1.0E-08"/>
@@ -555,9 +511,6 @@
         <sphere radius="0.001"/>
       </geometry>
     </collision>
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
 <xacro:unless value="$(arg gazebo)">
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -571,11 +524,7 @@
     <parent link="head"/>
     <child link="screen"/>
   </joint>
-  <link name="head_camera">
-<xacro:if value="$(arg gazebo)">
-    <xacro:gazebo_minimum_inertia />
-</xacro:if>
-  </link>
+  <link name="head_camera"/>
   <joint name="head_camera" type="fixed">
     <origin rpy="-2.1293 0 -1.57079632679" xyz="0.0228027 0 0.216572"/>
     <parent link="head"/>


### PR DESCRIPTION
New URDF Xacro args:
- Adds "static" parameter for linking Sawyer to world frame in Gazebo
- Adds "pedestal" parameter for removing Sawyer's pedestal and
  associated frames
- Removed minimum inertia macro as it is no longer needed now that gravity_comp is properly calculated)

Corresponds to https://github.com/RethinkRobotics/sawyer_simulator/pull/37